### PR TITLE
New features

### DIFF
--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -19,6 +19,15 @@ namespace Schafkopf.Hubs
                 return;
             }
             String user = ((Player)Context.Items["player"]).Name;
+            if (message.StartsWith("/kick"))
+            {
+                Player playerToKick = game.Players.Single(p => p.Name == message.Split("/kick ")[1]);
+                foreach (String connectionId in playerToKick.GetConnectionIds())
+                {
+                    await Clients.Client(connectionId).SendAsync("ReceiveKicked", user);
+                }
+                return;
+            }
             foreach (String connectionId in game.GetPlayersConnectionIds())
             {
                 await Clients.Client(connectionId).SendAsync("ReceiveChatMessage", user, message);
@@ -240,7 +249,8 @@ namespace Schafkopf.Hubs
                     {
                         await game.PlayerPlaysTheGame(player, this);
                     }
-                    else {
+                    else
+                    {
                         await game.SendAskWantToPlay(this, new List<string>() { Context.ConnectionId });
                     }
                 }

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -26,6 +26,10 @@ namespace Schafkopf.Hubs
                 {
                     await Clients.Client(connectionId).SendAsync("ReceiveKicked", user);
                 }
+                foreach (String connectionId in game.GetPlayingPlayersConnectionIds())
+                {
+                    await Clients.Client(connectionId).SendAsync("ReceiveSystemMessage", $"{user} hat {playerToKick.Name} rausgeworfen");
+                }
                 return;
             }
             foreach (String connectionId in game.GetPlayersConnectionIds())

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -79,7 +79,6 @@ namespace Schafkopf.Hubs
                         game.CurrentGameState = State.HochzeitExchangeCards;
                         game.HusbandWife = player;
                         game.ActionPlayer = game.PlayingPlayers.IndexOf(game.HusbandWife);
-                        await game.SendPlayers(this);
                         await game.SendAskExchangeCards(this, game.HusbandWife.GetConnectionIdsWithSpectators());
                     }
                     else
@@ -91,6 +90,7 @@ namespace Schafkopf.Hubs
                         await game.SendAskAnnounceHochzeit(this);
                     }
                 }
+                await game.SendPlayers(this);
             }
         }
 

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -374,13 +374,6 @@ namespace Schafkopf.Hubs
             {
                 await Clients.Client(connectionId).SendAsync("CloseWantToPlayModal");
             }
-            if (game.Players.Where((p => p.GetConnectionIds().Count > 0 && p.Playing)).ToList().Count <= 4)
-            {
-                foreach (Player p in game.Players.Where((p => p.GetConnectionIds().Count > 0 && p.Playing)))
-                {
-                    await game.PlayerPlaysTheGame(p, this);
-                }
-            }
         }
 
         public async Task ResetGame()
@@ -439,13 +432,10 @@ namespace Schafkopf.Hubs
                     {
                         Task asyncTask = game.SendPlayersInfo(this);
                         asyncTask = game.SendPlayers(this);
+                        asyncTask = game.PlayerDoesNotPlayTheGame(player, this);
                         if (game.PlayingPlayers.Contains(player))
                         {
-                            if (game.CurrentGameState == State.Idle)
-                            {
-                                asyncTask = game.PlayerDoesNotPlayTheGame(player, this);
-                            }
-                            else
+                            if (game.CurrentGameState != State.Idle)
                             {
                                 asyncTask = game.SendConnectionToPlayerLostModal(this, game.GetPlayingPlayersConnectionIds());
                                 asyncTask = game.ResetIfAllConnectionsLost(this);

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -164,7 +164,7 @@ namespace Schafkopf.Hubs
             {
                 if (!game.PlayingPlayers.Contains(player))
                 {
-                    await Clients.Caller.SendAsync("AskWantToPlay");
+                    await game.SendAskWantToPlay(this, new List<string>() { Context.ConnectionId });
                 }
             }
         }

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -64,6 +64,9 @@ namespace Schafkopf.Hubs
             Player player = (Player)Context.Items["player"];
             if (player == game.PlayingPlayers[game.ActionPlayer])
             {
+                if (gameType == GameType.Sauspiel && !await player.IsSauspielPossible(this)) {
+                    return;
+                }
                 await game.PlayingPlayers[game.ActionPlayer].AnnounceGameType(gameType, this, game);
                 game.ActionPlayer = (game.ActionPlayer + 1) % 4;
                 await game.SendAskForGameType(this);
@@ -100,6 +103,12 @@ namespace Schafkopf.Hubs
                 case "Schellen":
                     color = Color.Schellen;
                     break;
+            }
+            if (game.AnnouncedGame == GameType.Sauspiel) {
+                if (!await player.IsSauspielOnColorPossible(color, this))
+                {
+                    return;
+                }
             }
             game.Leader.AnnouncedColor = color;
             await game.StartGame(this);

--- a/Hubs/SchafkopfHub.cs
+++ b/Hubs/SchafkopfHub.cs
@@ -13,6 +13,11 @@ namespace Schafkopf.Hubs
         public async Task SendChatMessage(string message)
         {
             Game game = ((Game)Context.Items["game"]);
+            if (message == "/restart")
+            {
+                await game.Reset(this);
+                return;
+            }
             String user = ((Player)Context.Items["player"]).Name;
             foreach (String connectionId in game.GetPlayersConnectionIds())
             {
@@ -64,7 +69,8 @@ namespace Schafkopf.Hubs
             Player player = (Player)Context.Items["player"];
             if (player == game.PlayingPlayers[game.ActionPlayer])
             {
-                if (gameType == GameType.Sauspiel && !await player.IsSauspielPossible(this)) {
+                if (gameType == GameType.Sauspiel && !await player.IsSauspielPossible(this))
+                {
                     return;
                 }
                 await game.PlayingPlayers[game.ActionPlayer].AnnounceGameType(gameType, this, game);
@@ -104,7 +110,8 @@ namespace Schafkopf.Hubs
                     color = Color.Schellen;
                     break;
             }
-            if (game.AnnouncedGame == GameType.Sauspiel) {
+            if (game.AnnouncedGame == GameType.Sauspiel)
+            {
                 if (!await player.IsSauspielOnColorPossible(color, this))
                 {
                     return;
@@ -251,6 +258,22 @@ namespace Schafkopf.Hubs
         {
             Game game = ((Game)Context.Items["game"]);
             await game.Reset(this);
+        }
+
+        public async Task ShowLastTrick(bool showLastTrick)
+        {
+            Game game = ((Game)Context.Items["game"]);
+            Player player = (Player)Context.Items["player"];
+            if (showLastTrick && game.LastTrick != null)
+            {
+                await game.LastTrick.SendTrick(this, game, new List<string>() { Context.ConnectionId });
+                await game.SendLastTrickButton(this, new List<string>() { Context.ConnectionId }, LastTrickButtonState.hide);
+            }
+            else
+            {
+                await game.Trick.SendTrick(this, game, new List<string>() { Context.ConnectionId });
+                await game.SendLastTrickButton(this, new List<string>() { Context.ConnectionId }, LastTrickButtonState.show);
+            }
         }
 
         public override Task OnDisconnectedAsync(Exception exception)

--- a/Models/Card.cs
+++ b/Models/Card.cs
@@ -122,9 +122,9 @@ namespace Schafkopf.Models
             return value;
         }
 
-        internal bool IsTrump(Game game)
+        internal bool IsTrump(GameType gameType, Color trump)
         {
-            return GetValue(game.AnnouncedGame, game.Trick.Trump) > 500;
+            return GetValue(gameType, trump) > 500;
         }
     }
 }

--- a/Models/Card.cs
+++ b/Models/Card.cs
@@ -121,5 +121,10 @@ namespace Schafkopf.Models
             }
             return value;
         }
+
+        internal bool IsTrump(Game game)
+        {
+            return GetValue(game.AnnouncedGame, game.Trick.Trump) > 500;
+        }
     }
 }

--- a/Models/Card.cs
+++ b/Models/Card.cs
@@ -9,7 +9,7 @@ namespace Schafkopf.Models
     {
         public Color Color;
         public int Number;
-        public int Value = 0;
+        public int TrickValue = 0;
 
         public Card(Color color, int number)
         {
@@ -27,6 +27,99 @@ namespace Schafkopf.Models
         public override string ToString()
         {
             return Color + "-" + Number;
+        }
+
+        internal int GetValue(GameType gameType, Color trumpf, Card firstCard = null)
+        {
+            int value = 0;
+            switch (gameType)
+            {
+                //Highest card looses
+                case GameType.Ramsch:
+                case GameType.Hochzeit:
+                case GameType.Sauspiel:
+                    {
+                        //Determine value
+                        if (Number == 2 || Number == 3)
+                        {
+                            value = 1000 * Number + (int)Color;
+                        }
+                        else if (Color == trumpf && Number == 4)
+                        {
+                            value = 500 + 5 * 9 + Number;
+                        }
+                        else if (Color == trumpf)
+                        {
+                            value = 500 + 5 * Number;
+                        }
+                        else if (firstCard != null && Color != firstCard.Color)
+                        {
+                            value = 0;
+                        }
+                        else if (Number == 4)
+                        {
+                            value = (int)Color + 5 * 9 + Number;
+                        }
+                        else
+                        {
+                            value = (int)Color + 5 * Number;
+                        }
+                    }
+                    break;
+                case GameType.Wenz:
+                case GameType.WenzTout:
+                    {
+                        //Determine value
+                        if (Number == 2)
+                        {
+                            value = 1000 * Number + (int)Color;
+                        }
+                        else if (firstCard != null && Color != firstCard.Color)
+                        {
+                            value = 0;
+                        }
+                        else if (Number == 4 || Number == 3)
+                        {
+                            value = (int)Color + 5 * 9 + Number;
+                        }
+                        else
+                        {
+                            value = (int)Color + 5 * Number;
+                        }
+                    }
+                    break;
+                case GameType.Farbsolo:
+                case GameType.FarbsoloTout:
+                    {
+                        //Determine value
+                        if (Number == 2 || Number == 3)
+                        {
+                            value = 1000 * Number + (int)Color;
+                        }
+                        else if (Color == trumpf && Number == 4)
+                        {
+                            value = 500 + 5 * 9 + Number;
+                        }
+                        else if (Color == trumpf)
+                        {
+                            value = 500 + 5 * Number;
+                        }
+                        else if (firstCard != null && Color != firstCard.Color)
+                        {
+                            value = 0;
+                        }
+                        else if (Number == 4)
+                        {
+                            value = (int)Color + 5 * 9 + Number;
+                        }
+                        else
+                        {
+                            value = (int)Color + 5 * Number;
+                        }
+                    }
+                    break;
+            }
+            return value;
         }
     }
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Schafkopf.Models
 {
     public enum Color { Schellen, Herz, Gras, Eichel, None };
-    public enum State { Idle, Start, Playing };
+    public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, Playing };
     public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout }
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Schafkopf.Models
 {
-    public enum Color { Schellen, Herz, Gras, Eichel, None };
+    public enum Color { None, Schellen = 100, Herz = 200, Gras = 300, Eichel = 400 };
     public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, Playing };
     public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout }
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Schafkopf.Models
 {
     public enum Color { Schellen, Herz, Gras, Eichel, None };
-    public enum State { Idle, Start, Playing, End };
+    public enum State { Idle, Start, Playing };
     public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout }
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Schafkopf.Models
 {
     public enum Color { None, Schellen = 100, Herz = 200, Gras = 300, Eichel = 400 };
-    public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, Playing };
+    public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, HochzeitExchangeCards, Playing };
     public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout };
     public enum LastTrickButtonState { disabled, show, hide };
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -4,4 +4,5 @@
     public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, HochzeitExchangeCards, Playing };
     public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout };
     public enum LastTrickButtonState { disabled, show, hide };
+    public enum TakeTrickButtonState { hidden, won, lost };
 }

--- a/Models/EnumDefinitions.cs
+++ b/Models/EnumDefinitions.cs
@@ -2,5 +2,6 @@
 {
     public enum Color { None, Schellen = 100, Herz = 200, Gras = 300, Eichel = 400 };
     public enum State { Idle, AnnounceHochzeit, Announce, AnnounceGameType, AnnounceGameColor, Playing };
-    public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout }
+    public enum GameType { Ramsch, Sauspiel, Hochzeit, Wenz, Farbsolo, WenzTout, FarbsoloTout };
+    public enum LastTrickButtonState { disabled, show, hide };
 }

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -70,7 +70,8 @@ namespace Schafkopf.Models
 
         }
 
-        public async Task Reset(SchafkopfHub hub) {
+        public async Task Reset(SchafkopfHub hub)
+        {
             CurrentGameState = State.Idle;
             Groups = new int[] { 0, 0, 0, 0 };
             AnnouncedGame = GameType.Ramsch;
@@ -103,7 +104,8 @@ namespace Schafkopf.Models
                 await player.SendHand(hub);
             }
             await SendPlayers(hub);
-            foreach (String connectionId in GetPlayersConnectionIds()) {
+            foreach (String connectionId in GetPlayersConnectionIds())
+            {
                 await hub.Clients.Client(connectionId).SendAsync("CloseAnnounceModal");
                 await hub.Clients.Client(connectionId).SendAsync("CloseAnnounceGameTypeModal");
                 await hub.Clients.Client(connectionId).SendAsync("CloseGameColorModal");
@@ -112,9 +114,12 @@ namespace Schafkopf.Models
             }
         }
 
-        public async Task ResetIfAllConnectionsLost(SchafkopfHub hub) {
-            foreach (Player player in PlayingPlayers) {
-                if (player.GetConnectionIds().Count > 0) {
+        public async Task ResetIfAllConnectionsLost(SchafkopfHub hub)
+        {
+            foreach (Player player in PlayingPlayers)
+            {
+                if (player.GetConnectionIds().Count > 0)
+                {
                     return;
                 }
             }
@@ -182,7 +187,8 @@ namespace Schafkopf.Models
             await SendPlayerIsStartingTheRound(hub, GetPlayingPlayersConnectionIds());
         }
 
-        public async Task SendPlayerIsPlayingGameTypeAndColor(SchafkopfHub hub, List<String> connectionIds) {
+        public async Task SendPlayerIsPlayingGameTypeAndColor(SchafkopfHub hub, List<String> connectionIds)
+        {
             String message = "";
             if (AnnouncedGame == GameType.Farbsolo)
             {
@@ -196,7 +202,8 @@ namespace Schafkopf.Models
             {
                 message = $"Es wird geramscht!";
             }
-            else {
+            else
+            {
                 message = $"{Leader.Name} spielt {AnnouncedGame}";
             }
             foreach (String connectionId in connectionIds)
@@ -205,8 +212,10 @@ namespace Schafkopf.Models
             }
         }
 
-        public async Task SendPlayerIsStartingTheRound(SchafkopfHub hub, List<String> connectionIds) {
-            foreach (String connectionId in connectionIds) {
+        public async Task SendPlayerIsStartingTheRound(SchafkopfHub hub, List<String> connectionIds)
+        {
+            foreach (String connectionId in connectionIds)
+            {
                 await hub.Clients.Client(connectionId).SendAsync(
                     "ReceiveSystemMessage",
                     $"{PlayingPlayers[ActionPlayer].Name} kommt raus"
@@ -283,11 +292,14 @@ namespace Schafkopf.Models
             if (Trick.Count < 4)
             {
                 ActionPlayer = (ActionPlayer + 1) % 4;
-            } else {
+            }
+            else
+            {
                 Player winner = Trick.GetWinner();
                 winner.TakeTrick(Trick);
                 TrickCount++;
-                if (TrickCount == 8) {
+                if (TrickCount == 8)
+                {
                     await SendEndGameModal(hub, GetPlayingPlayersConnectionIds());
                 }
 
@@ -380,9 +392,12 @@ namespace Schafkopf.Models
                 throw new Exception("There is something wrong with the new player.");
             }
             Players.Add(player);
-            if (CurrentGameState == State.Idle) {
+            if (CurrentGameState == State.Idle)
+            {
                 await PlayerPlaysTheGame(player, hub);
-            } else {
+            }
+            else
+            {
                 await SendAskWantToSpectate(hub, player.GetConnectionIds());
             }
         }
@@ -427,13 +442,15 @@ namespace Schafkopf.Models
                                 break;
                             }
                         }
-                        if (!PlayingPlayers.Contains(player)) {
+                        if (!PlayingPlayers.Contains(player))
+                        {
                             PlayingPlayers.Add(player);
                         }
                     }
                 }
-                await hub.UpdatePlayingPlayers();
-                if (PlayingPlayers.Count == 4) {
+                await UpdatePlayingPlayers(hub);
+                if (PlayingPlayers.Count == 4)
+                {
                     await DealCards(hub);
                 }
             }
@@ -461,7 +478,7 @@ namespace Schafkopf.Models
                 {
                     PlayingPlayers.Remove(player);
                 }
-                await hub.UpdatePlayingPlayers();
+                await UpdatePlayingPlayers(hub);
             }
         }
         #endregion
@@ -490,7 +507,8 @@ namespace Schafkopf.Models
             HusbandWife = p;
         }
 
-        public async Task SendConnectionToPlayerLostModal(SchafkopfHub hub, List<string> connectionIds) {
+        public async Task SendConnectionToPlayerLostModal(SchafkopfHub hub, List<string> connectionIds)
+        {
             foreach (String connectionId in connectionIds)
             {
                 await hub.Clients.Client(connectionId).SendAsync(
@@ -501,7 +519,8 @@ namespace Schafkopf.Models
             }
         }
 
-        public List<String> GetPlayingPlayersConnectionIds() {
+        public List<String> GetPlayingPlayersConnectionIds()
+        {
             return PlayingPlayers.Aggregate(new List<String>(), (acc, x) => acc.Concat(x.GetConnectionIdsWithSpectators()).ToList());
         }
 
@@ -519,12 +538,13 @@ namespace Schafkopf.Models
 
         public async Task SendPlayers(SchafkopfHub hub)
         {
-            if (PlayingPlayers.Count != 4) {
+            if (PlayingPlayers.Count != 4)
+            {
                 foreach (String connectionId in GetPlayersConnectionIds())
                 {
                     await hub.Clients.Client(connectionId).SendAsync(
                         "ReceivePlayers",
-                        new String[4] {"", "", "", ""}
+                        new String[4] { "", "", "", "" }
                     );
                 }
                 return;
@@ -546,7 +566,8 @@ namespace Schafkopf.Models
             }
         }
 
-        public async Task SendAskAnnounce(SchafkopfHub hub) {
+        public async Task SendAskAnnounce(SchafkopfHub hub)
+        {
             foreach (String connectionId in PlayingPlayers[ActionPlayer].GetConnectionIdsWithSpectators())
             {
                 await hub.Clients.Client(connectionId).SendAsync("AskAnnounce");
@@ -610,7 +631,8 @@ namespace Schafkopf.Models
             }
         }
 
-        public async Task SendUpdatedGameState(Player player, SchafkopfHub hub) {
+        public async Task SendUpdatedGameState(Player player, SchafkopfHub hub)
+        {
             if (CurrentGameState == State.Playing)
             {
                 await SendPlayerIsPlayingGameTypeAndColor(hub, new List<string>() { hub.Context.ConnectionId });
@@ -649,6 +671,16 @@ namespace Schafkopf.Models
             if (Leader == player && CurrentGameState == State.AnnounceGameColor)
             {
                 await SendAskForGameColor(hub);
+            }
+        }
+        public async Task UpdatePlayingPlayers(SchafkopfHub hub)
+        {
+            foreach (String connectionId in GetPlayersConnectionIds())
+            {
+                await hub.Clients.Client(connectionId).SendAsync(
+                    "ReceiveSystemMessage",
+                    $"Playing Players: {String.Join(", ", PlayingPlayers.Select(p => p.Name + " (" + p.GetConnectionIds().Count + ")"))}"
+                );
             }
         }
     }

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -284,9 +284,16 @@ namespace Schafkopf.Models
         {
             if (player != PlayingPlayers[ActionPlayer] || CurrentGameState != State.Playing)
             {
+                foreach (String connectionId in player.GetConnectionIds())
+                {
+                    await hub.Clients.Client(connectionId).SendAsync("ReceiveSystemMessage", "Du bist gerade nicht dran!");
+                }
                 return;
             }
             Card playedCard = await player.PlayCard(cardColor, cardNumber, hub, this);
+            if (playedCard == null) {
+                return;
+            }
             await Trick.AddCard(playedCard, player, hub, this);
 
             if (Trick.Count < 4)

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -735,11 +735,19 @@ namespace Schafkopf.Models
             {
                 predictedStartPlayer = (StartPlayer + 1) % Players.Count;
             }
-            String players = String.Join(", ", Players.Where(p => p.GetConnectionIds().Count > 0).Select(p => p.Name));
-            String startPlayer = Players[predictedStartPlayer].Name;
-            foreach (String connectionId in connectionIds)
+            string players = String.Join(", ", Players.Where(p => p.GetConnectionIds().Count > 0).Select(p => p.Name));
+            string startPlayer = Players[predictedStartPlayer].Name;
+            int playerCnt = Players.Where(p => p.GetConnectionIds().Count > 0).ToList().Count;
+            string proposal =
+$@"
+{Players[predictedStartPlayer].Name},
+{Players[(int)Math.Floor(predictedStartPlayer + 1m * playerCnt / 4m) % playerCnt].Name},
+{Players[(int)Math.Floor(predictedStartPlayer + 2m * playerCnt / 4m) % playerCnt].Name},
+{Players[(int)Math.Floor(predictedStartPlayer + 3m * playerCnt / 4m) % playerCnt].Name}
+";
+            foreach (string connectionId in connectionIds)
             {
-                await hub.Clients.Client(connectionId).SendAsync("AskWantToPlay", players, startPlayer);
+                await hub.Clients.Client(connectionId).SendAsync("AskWantToPlay", players, startPlayer, proposal);
             }
         }
 

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -446,6 +446,8 @@ namespace Schafkopf.Models
                 await UpdatePlayingPlayers(hub);
                 if (PlayingPlayers.Count == 4)
                 {
+                    // wait for a second to make sure old other modals have closed
+                    await Task.Delay(1000);
                     await DealCards(hub);
                 }
             }

--- a/Models/Game.cs
+++ b/Models/Game.cs
@@ -23,7 +23,7 @@ namespace Schafkopf.Models
         public GameType AnnouncedGame = GameType.Ramsch;
         public Player Leader = null;
         public Player HusbandWife = null;
-        public Trick Trick = new Trick();
+        public Trick Trick = null;
         public int TrickCount = 0;
 
         private Random random = new Random();
@@ -76,7 +76,7 @@ namespace Schafkopf.Models
             AnnouncedGame = GameType.Ramsch;
             Leader = null;
             HusbandWife = null;
-            Trick = new Trick();
+            Trick = null;
             TrickCount = 0;
 
             // TODO: let players stay in the game if they want
@@ -95,7 +95,7 @@ namespace Schafkopf.Models
             //         player.AskIfWantToPlay();
             //     }
             // }
-            await Trick.SendTrick(hub, this);
+            await new Trick(this).SendTrick(hub, this);
             PlayingPlayers = new List<Player>();
             foreach (Player player in Players)
             {
@@ -176,7 +176,7 @@ namespace Schafkopf.Models
         {
             await SendPlayerIsPlayingGameTypeAndColor(hub, GetPlayingPlayersConnectionIds());
             FindTeams();
-            Trick.DetermineTrumpf(this);
+            Trick = new Trick(this);
             CurrentGameState = State.Playing;
             ActionPlayer = StartPlayer;
             await SendPlayerIsStartingTheRound(hub, GetPlayingPlayersConnectionIds());
@@ -292,8 +292,7 @@ namespace Schafkopf.Models
                 }
 
                 ActionPlayer = PlayingPlayers.FindIndex(p => p == winner);
-                Trick = new Trick();
-                Trick.DetermineTrumpf(this);
+                Trick = new Trick(this);
                 await SendPlayerIsStartingTheRound(hub, GetPlayingPlayersConnectionIds());
             }
         }
@@ -619,9 +618,9 @@ namespace Schafkopf.Models
                 {
                     await SendPlayerIsStartingTheRound(hub, new List<string>() { hub.Context.ConnectionId });
                 }
+                await Trick.SendTrick(hub, this);
             }
             await player.SendHand(hub);
-            await Trick.SendTrick(hub, this);
             await SendPlayers(hub);
             // send modals
             if (CurrentGameState == State.Playing && TrickCount == 8)

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -15,7 +15,7 @@ namespace Schafkopf.Models
         public String Name = "";
         public String Id = "";
         private readonly List<String> _connectionIds = new List<String>();
-        public Boolean Playing = false;
+        public Boolean Playing = true;
         public Boolean WantToPlay = false;
         public Boolean WantToPlayAnswered = false;
         public GameType AnnouncedGameType = GameType.Ramsch;
@@ -38,7 +38,7 @@ namespace Schafkopf.Models
         {
             HandCards = new List<Card>();
             Balance = 0;
-            Playing = false;
+            Playing = true;
             WantToPlay = false;
             WantToPlayAnswered = false;
             AnnouncedGameType = GameType.Ramsch;

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -161,7 +161,7 @@ namespace Schafkopf.Models
                 await hub.Clients.Client(connectionId).SendAsync("ReceiveSystemMessage", $"{player.Name} schaut jetzt bei {Name} zu");
             }
             Spectators.Add(player);
-            await game.SendUpdatedGameState(this, hub);
+            await game.SendUpdatedGameState(this, hub, player.GetConnectionIds());
         }
 
         public async Task AskForApprovalToSpectate(SchafkopfHub hub)

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -46,13 +46,13 @@ namespace Schafkopf.Models
         // Card will be removed from the hand-cards
         // Throw exception in case that a card has been played twice
         //-------------------------------------------------
-        public async Task<Card> PlayCard(Color cardColor, int cardNumber, SchafkopfHub hub)
+        public async Task<Card> PlayCard(Color cardColor, int cardNumber, SchafkopfHub hub, Game game)
         {
             foreach (Card card in HandCards) {
                 if (card.Color == cardColor && card.Number == cardNumber)
                 {
                     HandCards.Remove(card);
-                    await SendHand(hub);
+                    await SendHand(hub, game.AnnouncedGame, game.Trick.Trump);
                     return card;
                 }
             }
@@ -132,12 +132,12 @@ namespace Schafkopf.Models
             return GetSpectatorConnectionIds().Concat(GetConnectionIds()).ToList();
         }
 
-        public async Task SendHand(SchafkopfHub hub) {
+        public async Task SendHand(SchafkopfHub hub, GameType gameType = GameType.Ramsch, Color trump = Color.Herz) {
             foreach (String connectionId in GetConnectionIdsWithSpectators())
             {
                 await hub.Clients.Client(connectionId).SendAsync(
                     "ReceiveHand",
-                    HandCards.Select(card => card.ToString())
+                    HandCards.OrderByDescending(c => c.GetValue(gameType, trump)).Select(card => card.ToString())
                 );
             }
         }

--- a/Models/Player.cs
+++ b/Models/Player.cs
@@ -64,14 +64,20 @@ namespace Schafkopf.Models
             Balance += points;
         }
 
-        public async Task Announce(bool wantToPlay, SchafkopfHub hub)
+        public async Task Announce(bool wantToPlay, SchafkopfHub hub, Game game)
         {
             //Message about the players actions
             WantToPlay = wantToPlay;
-            if (WantToPlay) {
-                await hub.Clients.All.SendAsync("ReceiveChatMessage", Name, "ich mag spielen");
-            } else {
-                await hub.Clients.All.SendAsync("ReceiveChatMessage", Name, "ich mag nicht spielen");
+            foreach (String connectionId in game.GetPlayingPlayersConnectionIds())
+            {
+                if (WantToPlay)
+                {
+                    await hub.Clients.Client(connectionId).SendAsync("ReceiveChatMessage", Name, "ich mag spielen");
+                }
+                else
+                {
+                    await hub.Clients.Client(connectionId).SendAsync("ReceiveChatMessage", Name, "ich mag nicht spielen");
+                }
             }
         }
 
@@ -94,27 +100,13 @@ namespace Schafkopf.Models
         {
             AnnouncedGameType = gameTyp;
         }
-        internal async Task AnnounceGameType(GameType gameType, SchafkopfHub hub)
+        internal async Task AnnounceGameType(GameType gameType, SchafkopfHub hub, Game game)
         {
             AnnouncedGameType = gameType;
             //Message about the players actions
-            await hub.Clients.All.SendAsync("ReceiveChatMessage", Name, $"Ich hätte ein {gameType}");
-        }
-
-        public override bool Equals(object obj)
-        {
-            Player secondPlayer = obj as Player;
-
-            if(this.Name.Equals(secondPlayer.Name))
-            {
-                return true;
+            foreach (String connectionId in game.GetPlayingPlayersConnectionIds()) {
+                await hub.Clients.Client(connectionId).SendAsync("ReceiveChatMessage", Name, $"Ich hätte ein {gameType}");
             }
-            return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
 
         public void AddConnectionId(SchafkopfHub hub) {

--- a/Models/Trick.cs
+++ b/Models/Trick.cs
@@ -17,9 +17,10 @@ namespace Schafkopf.Models
         public Color Trumpf = Color.Herz;
         public int Winner = 0;
 
-        public Trick()
+        public Trick(Game game)
         {
-
+            GameType = game.AnnouncedGame;
+            DetermineTrumpf(game);
         }
 
         //-------------------------------------------------
@@ -245,7 +246,7 @@ namespace Schafkopf.Models
             return Player[Winner];
         }
 
-        public void DetermineTrumpf(Game game) {
+        private void DetermineTrumpf(Game game) {
             switch (game.AnnouncedGame)
             {
                 case GameType.Ramsch:

--- a/Models/Trick.cs
+++ b/Models/Trick.cs
@@ -14,7 +14,7 @@ namespace Schafkopf.Models
         public Card FirstCard;
         public int Count = 0;
         public GameType GameType = GameType.Ramsch;
-        public Color Trumpf = Color.Herz;
+        public Color Trump = Color.Herz;
         public int Winner = 0;
 
         public Trick(Game game)
@@ -45,85 +45,7 @@ namespace Schafkopf.Models
             } else
             {
                 FirstCard = card;
-                switch (this.GameType)
-                {
-                    //Highest card looses
-                    case GameType.Ramsch:
-                    case GameType.Hochzeit:
-                    case GameType.Sauspiel:
-                        {
-                            //Determine value
-                            if (card.Number == 2 || card.Number == 3)
-                            {
-                                card.Value = 100 * card.Number + (int)card.Color;
-                            }
-                            else if (card.Color == Trumpf && card.Number == 4)
-                            {
-                                card.Value = 29;
-                            }
-                            else if (card.Color == Trumpf)
-                            {
-                                card.Value = 3 * card.Number;
-                            }
-                            else if (card.Number == 4)
-                            {
-                                card.Value = 19;
-                            }
-                            else
-                            {
-                                card.Value = 2 * card.Number;
-                            }
-                        }
-                        break;
-                    case GameType.Wenz:
-                    case GameType.WenzTout:
-                        {
-                            //Determine value
-                            if (card.Number == 2)
-                            {
-                                card.Value = 100 * card.Number + (int)card.Color;
-                            }
-                            else if (card.Number == 4)
-                            {
-                                card.Value = 29;
-                            }
-                            else if (card.Number == 3)
-                            {
-                                card.Value = 28;
-                            }
-                            else
-                            {
-                                card.Value = 3 * card.Number;
-                            }
-                        }
-                        break;
-                    case GameType.Farbsolo:
-                    case GameType.FarbsoloTout:
-                        {
-                            //Determine value
-                            if (card.Number == 2 || card.Number == 3)
-                            {
-                                card.Value = 100 * card.Number + (int)card.Color;
-                            }
-                            else if (card.Color == Trumpf && card.Number == 4)
-                            {
-                                card.Value = 29;
-                            }
-                            else if (card.Color == Trumpf)
-                            {
-                                card.Value = 3 * card.Number;
-                            }
-                            else if (card.Number == 4)
-                            {
-                                card.Value = 19;
-                            }
-                            else
-                            {
-                                card.Value = 2 * card.Number;
-                            }
-                        }
-                        break;
-                }
+                FirstCard.TrickValue = card.GetValue(GameType, Trump);
             }
             Count++;
         }
@@ -135,109 +57,11 @@ namespace Schafkopf.Models
         //-------------------------------------------------
         private void DetermineWinnerCard(Card newCard)
         {
-            switch (this.GameType)
+            newCard.TrickValue = newCard.GetValue(GameType, Trump, FirstCard);
+            //Check which one is higher
+            if (newCard.TrickValue > Cards[Winner].TrickValue)
             {
-                //Highest card looses
-                case GameType.Ramsch:
-                case GameType.Hochzeit:
-                case GameType.Sauspiel:
-                    {
-                        //Determine value
-                        if(newCard.Number == 2 || newCard.Number == 3)
-                        {
-                            newCard.Value = 100 * newCard.Number + (int)newCard.Color;
-                        } else if(newCard.Color == Trumpf && newCard.Number == 4)
-                        {
-                            newCard.Value = 29;
-                        } else if(newCard.Color == Trumpf)
-                        {
-                            newCard.Value = 3 * newCard.Number;
-                        } else if(newCard.Color != FirstCard.Color)
-                        {
-                            newCard.Value = 0;
-                        } else if(newCard.Number == 4)
-                        {
-                            newCard.Value = 19;
-                        } else
-                        {
-                            newCard.Value = 2 * newCard.Number;
-                        }
-
-                        //Check which one is higher
-                        if(newCard.Value > Cards[Winner].Value)
-                        {
-                            Winner = Count;
-                        }
-                    }
-                    break;
-                case GameType.Wenz:
-                case GameType.WenzTout:
-                    {
-                        //Determine value
-                        if (newCard.Number == 2)
-                        {
-                            newCard.Value = 100 * newCard.Number + (int)newCard.Color;
-                        }
-                        else if (newCard.Color != FirstCard.Color)
-                        {
-                            newCard.Value = 0;
-                        }
-                        else if (newCard.Number == 4)
-                        {
-                            newCard.Value = 29;
-                        }
-                        else if (newCard.Number == 3)
-                        {
-                            newCard.Value = 28;
-                        }
-                        else
-                        {
-                            newCard.Value = 3 * newCard.Number;
-                        }
-
-                        //Check which one is higher
-                        if (newCard.Value > Cards[Winner].Value)
-                        {
-                            Winner = Count;
-                        }
-                    }
-                    break;
-                case GameType.Farbsolo:
-                case GameType.FarbsoloTout:
-                    {
-                        //Determine value
-                        if (newCard.Number == 2 || newCard.Number == 3)
-                        {
-                            newCard.Value = 100 * newCard.Number + (int)newCard.Color;
-                        }
-                        else if (newCard.Color == Trumpf && newCard.Number == 4)
-                        {
-                            newCard.Value = 29;
-                        }
-                        else if (newCard.Color == Trumpf)
-                        {
-                            newCard.Value = 3 * newCard.Number;
-                        }
-                        else if (newCard.Color != FirstCard.Color)
-                        {
-                            newCard.Value = 0;
-                        }
-                        else if (newCard.Number == 4)
-                        {
-                            newCard.Value = 19;
-                        }
-                        else
-                        {
-                            newCard.Value = 2 * newCard.Number;
-                        }
-
-                        //Check which one is higher
-                        if (newCard.Value > Cards[Winner].Value)
-                        {
-                            Winner = Count;
-                        }
-                    }
-                    break;
+                Winner = Count;
             }
         }
 
@@ -252,15 +76,15 @@ namespace Schafkopf.Models
                 case GameType.Ramsch:
                 case GameType.Sauspiel:
                 case GameType.Hochzeit:
-                    Trumpf = Color.Herz;
+                    Trump = Color.Herz;
                     break;
                 case GameType.Farbsolo:
                 case GameType.FarbsoloTout:
-                    Trumpf = game.Leader.AnnouncedColor;
+                    Trump = game.Leader.AnnouncedColor;
                     break;
                 case GameType.Wenz:
                 case GameType.WenzTout:
-                    Trumpf = Color.None;
+                    Trump = Color.None;
                     break;
             }
         }

--- a/Models/Trick.cs
+++ b/Models/Trick.cs
@@ -274,7 +274,7 @@ namespace Schafkopf.Models
                     permutedCards[j] = Cards[(j + i) % 4];
                 }
                 Player player = game.PlayingPlayers[(game.ActionPlayer - Count + i + 4) % 4];
-                foreach (String connectionId in player.GetConnectionIds())
+                foreach (String connectionId in player.GetConnectionIdsWithSpectators())
                 {
                     await hub.Clients.Client(connectionId).SendAsync(
                         "ReceiveTrick",

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -138,6 +138,8 @@
       <div class="modal-header">
         <h5 class="modal-title">Willst du nächste Runde mitspielen?</h5>
       </div>
+      <div class="modal-body" id="wantToPlayModalBody">
+      </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" id="wantToPauseButton">Erstmal aussetzen.</button>
         <button type="button" class="btn btn-primary" id="wantToPlayButton">Bin dabei!</button>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -209,5 +209,18 @@
   </div>
 </div>
 
+<div class="modal fade text-dark" id="reconnectModal" tabindex="-1" role="dialog" >
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="reconnectModalTitle"></h5>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="reconnectButton"></button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="~/js/signalr/dist/browser/signalr.js"></script>
 <script src="~/js/schafkopf.js"></script>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,11 +1,15 @@
 ﻿@page
         <div class="d-flex flex-grow-1 overflow-hidden">
             <div class="col-9 overflow-hidden d-flex flex-column  pl-0 pr-0">
-                <div class="flex-grow-1 w-100" style="transform: translateY(50%);">
+                <div class="flex-grow-1 w-100" style="transform: translateY(0);">
                     <img src="" class="card-on-table" id="card-left">
                     <img src="" class="card-on-table" id="card-right">
                     <img src="" class="card-on-table" id="card-top">
                     <img src="" class="card-on-table" id="card-bottom">
+                    <div class="player-at-table card-on-table" id="player-left"></div>
+                    <div class="player-at-table card-on-table" id="player-right"></div>
+                    <div class="player-at-table card-on-table" id="player-top"></div>
+                    <div class="player-at-table card-on-table" id="player-bottom"></div>
                 </div>
                 <div id="hand"></div>
             </div>
@@ -103,7 +107,7 @@
         <h5 class="modal-title">Willst du nächste Runde mitspielen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal">Erstmal aussetzen.</button>
+        <button type="button" class="btn btn-secondary" id="wantToPauseButton" data-dismiss="modal">Erstmal aussetzen.</button>
         <button type="button" class="btn btn-primary" id="wantToPlayButton" data-dismiss="modal">Bin dabei!</button>
       </div>
     </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -2,14 +2,36 @@
         <div class="d-flex flex-grow-1 overflow-hidden">
             <div class="col-9 overflow-hidden d-flex flex-column  pl-0 pr-0">
                 <div class="flex-grow-1 w-100" style="transform: translateY(0);">
+                    <div class="card-on-table float-box" id="game-info">
+                    </div>
                     <img src="" class="card-on-table" id="card-left">
                     <img src="" class="card-on-table" id="card-right">
                     <img src="" class="card-on-table" id="card-top">
                     <img src="" class="card-on-table" id="card-bottom">
-                    <div class="player-at-table card-on-table" id="player-left"></div>
-                    <div class="player-at-table card-on-table" id="player-right"></div>
-                    <div class="player-at-table card-on-table" id="player-top"></div>
-                    <div class="player-at-table card-on-table" id="player-bottom"></div>
+                    <div class="card-on-table d-flex flex-row" id="player-left">
+                      <div id="player-left-name" class="float-box">
+                      </div>
+                      <div id="player-left-info" class="float-box">
+                      </div>
+                    </div>
+                    <div class="card-on-table d-flex flex-row" id="player-right">
+                      <div id="player-right-info" class="float-box">
+                      </div>
+                      <div id="player-right-name" class="float-box">
+                      </div>
+                    </div>
+                    <div class="card-on-table d-flex flex-column" id="player-top">
+                      <div id="player-top-name" class="float-box">
+                      </div>
+                      <div id="player-top-info" class="float-box">
+                      </div>
+                    </div>
+                    <div class="card-on-table d-flex flex-column" id="player-bottom">
+                      <div id="player-bottom-info" class="float-box">
+                      </div>
+                      <div id="player-bottom-name" class="float-box">
+                      </div>
+                    </div>
                     <div class="card-on-table" style="width: 11%;">
                       <div style="padding-bottom:100%;">
                         <div id="take-trick-btn" class="btn d-none d-flex">

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -145,5 +145,21 @@
   </div>
 </div>
 
+<div class="modal fade" id="gameIdModal" tabindex="-1" role="dialog" >
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Wie soll das Spiel heißen?</h5>
+      </div>
+      <div class="modal-body">
+        <input class="form-control" type="text" id="gameIdInput" />
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="gameIdSubmitButton">Los geht's!</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="~/js/signalr/dist/browser/signalr.js"></script>
 <script src="~/js/schafkopf.js"></script>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,25 +1,16 @@
 ﻿@page
-        <div class="row h-100 overflow-hidden">
-            <div class="col-9 overflow-auto h-100 d-flex flex-column">
-                <div class="row flex-grow-1 overflow-hidden">
-
-                  <!-- the positioning here is kinda hacky, but it works -->
-                  <div class="row w-100" style="transform: translateY(50%);">
-                      <img src="" class="card-on-table" id="card-left">
-                      <img src="" class="card-on-table" id="card-right">
-                      <img src="" class="card-on-table" id="card-top">
-                      <img src="" class="card-on-table" id="card-bottom">
-                    </div>
-
+        <div class="d-flex flex-grow-1 overflow-hidden">
+            <div class="col-9 overflow-hidden d-flex flex-column  pl-0 pr-0">
+                <div class="flex-grow-1 w-100" style="transform: translateY(50%);">
+                    <img src="" class="card-on-table" id="card-left">
+                    <img src="" class="card-on-table" id="card-right">
+                    <img src="" class="card-on-table" id="card-top">
+                    <img src="" class="card-on-table" id="card-bottom">
                 </div>
-                <div class="row">
-                    <!--style="position: absolute; bottom: 0;"-->
-                    <div id="hand" class="col">
-                    </div>
-                </div>
+                <div id="hand"></div>
             </div>
 
-            <div class="col-3 h-100 d-flex flex-column overflow-hidden">
+            <div class="col-3 d-flex flex-column overflow-hidden pr-0">
                 <div id="messagesList" class="flex-grow-1 overflow-auto"></div>
                 <div class="input-group">
                     <input type="text" class="form-control" id="messageInput" />

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -28,7 +28,7 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Magst du spielen?</h5>
+        <h5 class="modal-title" id="announceModalTitle"></h5>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" id="announceNoButton">Nein</button>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -31,8 +31,8 @@
         <h5 class="modal-title">Magst du spielen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" id="announceNoButton" data-dismiss="modal">Nein</button>
-        <button type="button" class="btn btn-primary" id="announceYesButton" data-dismiss="modal">Ja</button>
+        <button type="button" class="btn btn-secondary" id="announceNoButton">Nein</button>
+        <button type="button" class="btn btn-primary" id="announceYesButton">Ja</button>
       </div>
     </div>
   </div>
@@ -45,9 +45,9 @@
         <h5 class="modal-title">Was magst du spielen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="announceSoloButton" data-dismiss="modal">Solo</button>
-        <button type="button" class="btn btn-primary" id="announceWenzButton" data-dismiss="modal">Wenz</button>
-        <button type="button" class="btn btn-primary" id="announceSauspielButton" data-dismiss="modal">Sauspiel</button>
+        <button type="button" class="btn btn-primary" id="announceSoloButton">Solo</button>
+        <button type="button" class="btn btn-primary" id="announceWenzButton">Wenz</button>
+        <button type="button" class="btn btn-primary" id="announceSauspielButton">Sauspiel</button>
       </div>
     </div>
   </div>
@@ -60,10 +60,10 @@
         <h5 class="modal-title">Was magst du spielen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="eichelButton" data-dismiss="modal">Eichel</button>
-        <button type="button" class="btn btn-primary" id="grasButton" data-dismiss="modal">Gras</button>
-        <button type="button" class="btn btn-primary" id="herzButton" data-dismiss="modal">Herz</button>
-        <button type="button" class="btn btn-primary" id="schellenButton" data-dismiss="modal">Schellen</button>
+        <button type="button" class="btn btn-primary" id="eichelButton">Eichel</button>
+        <button type="button" class="btn btn-primary" id="grasButton">Gras</button>
+        <button type="button" class="btn btn-primary" id="herzButton">Herz</button>
+        <button type="button" class="btn btn-primary" id="schellenButton">Schellen</button>
       </div>
     </div>
   </div>
@@ -79,7 +79,7 @@
         <input class="form-control" type="text" id="startModalUserName" />
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="startButton" data-dismiss="modal">Los geht's!</button>
+        <button type="button" class="btn btn-primary" id="startButton">Los geht's!</button>
       </div>
     </div>
   </div>
@@ -94,7 +94,7 @@
       <div class="modal-body" id="gameOverModalBody">
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="restartButton" data-dismiss="modal">Neues Spiel starten!</button>
+        <button type="button" class="btn btn-primary" id="restartButton">Neues Spiel starten!</button>
       </div>
     </div>
   </div>
@@ -107,8 +107,39 @@
         <h5 class="modal-title">Willst du nächste Runde mitspielen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" id="wantToPauseButton" data-dismiss="modal">Erstmal aussetzen.</button>
-        <button type="button" class="btn btn-primary" id="wantToPlayButton" data-dismiss="modal">Bin dabei!</button>
+        <button type="button" class="btn btn-secondary" id="wantToPauseButton">Erstmal aussetzen.</button>
+        <button type="button" class="btn btn-primary" id="wantToPlayButton">Bin dabei!</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="wantToSpectateModal" tabindex="-1" role="dialog" >
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Magst du bei jemand zuschauen?</h5>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" id="doNotSpectateButton">Nicht zuschauen.</button>
+        <button type="button" class="btn btn-primary" id="wantToSpectatePlayer1Button"></button>
+        <button type="button" class="btn btn-primary" id="wantToSpectatePlayer2Button"></button>
+        <button type="button" class="btn btn-primary" id="wantToSpectatePlayer3Button"></button>
+        <button type="button" class="btn btn-primary" id="wantToSpectatePlayer4Button"></button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="allowSpectatorModal" tabindex="-1" role="dialog" >
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="allowSpectatorModalTitle"></h5>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" id="doNotAllowSpectatorButton">Zuschauen verbieten.</button>
+        <button type="button" class="btn btn-primary" id="allowSpectatorButton">Zuschauen erlauben</button>
       </div>
     </div>
   </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -16,10 +16,10 @@
 
             <div class="col-3 d-flex flex-column overflow-hidden pr-0">
                 <div id="messagesList" class="flex-grow-1 overflow-auto"></div>
-                <div class="input-group">
+                <form id="chatInput" class="input-group">
                     <input type="text" class="form-control" id="messageInput" />
-                    <input class="btn btn-primary" type="button" id="sendButton" value="Send" />
-                </div>
+                    <input class="btn btn-primary" type="submit" id="sendButton" value="Send" />
+                </form>
             </div>
         </div>
 

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -83,12 +83,14 @@
       <div class="modal-header">
         <h5 class="modal-title">Wie heißt du?</h5>
       </div>
-      <div class="modal-body">
-        <input class="form-control" type="text" id="startModalUserName" />
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="startButton">Los geht's!</button>
-      </div>
+      <form id="userNameInput">
+        <div class="modal-body">
+          <input class="form-control" type="text" id="startModalUserName" />
+        </div>
+        <div class="modal-footer">
+          <input type="submit" class="btn btn-primary" id="startButton" value="Los geht's!"/>
+        </div>
+      </form>
     </div>
   </div>
 </div>
@@ -164,6 +166,21 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-primary" id="gameIdSubmitButton">Los geht's!</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade text-dark" id="errorModal" tabindex="-1" role="dialog" >
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Fehler!</h5>
+      </div>
+      <div class="modal-body" id="errorModalBody">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Schließen</button>
       </div>
     </div>
   </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -184,12 +184,14 @@
       <div class="modal-header">
         <h5 class="modal-title">Wie soll das Spiel heißen?</h5>
       </div>
-      <div class="modal-body">
-        <input class="form-control" type="text" id="gameIdInput" />
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-primary" id="gameIdSubmitButton">Los geht's!</button>
-      </div>
+      <form id="userNameInput">
+        <div class="modal-body">
+          <input class="form-control" type="text" id="gameIdInput" />
+        </div>
+        <div class="modal-footer">
+          <input type="submit" class="btn btn-primary" id="gameIdSubmitButton" value="Los geht's!"/>
+        </div>
+      </form>
     </div>
   </div>
 </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -10,6 +10,14 @@
                     <div class="player-at-table card-on-table" id="player-right"></div>
                     <div class="player-at-table card-on-table" id="player-top"></div>
                     <div class="player-at-table card-on-table" id="player-bottom"></div>
+                    <div class="card-on-table" style="width: 11%;">
+                      <div style="padding-bottom:100%;">
+                        <div id="take-trick-btn" class="btn d-none d-flex">
+                          <div id="take-trick-btn-content">
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                 </div>
                 <div id="hand"></div>
             </div>

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -24,7 +24,7 @@
         </div>
 
 
-<div class="modal fade" id="announceModal" tabindex="-1" role="dialog">
+<div class="modal fade text-dark" id="announceModal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -38,7 +38,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="announceGameTypeModal" tabindex="-1" role="dialog">
+<div class="modal fade text-dark" id="announceGameTypeModal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -53,7 +53,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="gameColorModal" tabindex="-1" role="dialog">
+<div class="modal fade text-dark" id="gameColorModal" tabindex="-1" role="dialog">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -69,7 +69,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="usernameModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="usernameModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -85,7 +85,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="gameOverModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="gameOverModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -100,7 +100,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="wantToPlayModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="wantToPlayModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -114,7 +114,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="wantToSpectateModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="wantToSpectateModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -131,7 +131,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="allowSpectatorModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="allowSpectatorModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -145,7 +145,7 @@
   </div>
 </div>
 
-<div class="modal fade" id="gameIdModal" tabindex="-1" role="dialog" >
+<div class="modal fade text-dark" id="gameIdModal" tabindex="-1" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -110,7 +110,7 @@
           <input class="form-control" type="text" id="startModalUserName" />
         </div>
         <div class="modal-footer">
-          <input type="submit" class="btn btn-primary" id="startButton" value="Los geht's!"/>
+          <input type="submit" class="btn btn-primary" id="startButton" value="Das bin ich!"/>
         </div>
       </form>
     </div>
@@ -150,10 +150,9 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Magst du bei jemand zuschauen?</h5>
+        <h5 class="modal-title">Bei wem magst du zuschauen?</h5>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" id="doNotSpectateButton">Nicht zuschauen.</button>
         <button type="button" class="btn btn-primary" id="wantToSpectatePlayer1Button"></button>
         <button type="button" class="btn btn-primary" id="wantToSpectatePlayer2Button"></button>
         <button type="button" class="btn btn-primary" id="wantToSpectatePlayer3Button"></button>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-page="/Index">Schafkopf</a>
+                <a class="navbar-brand" href="/">Schafkopf</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -21,16 +21,13 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Index">Home</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link" href="javascript:document.body.requestFullscreen();">Vollbild</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" id="toggleThemeButton" href="">Dark</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" id="toggleLastTrickButton" href=""></a>
+                            <a class="nav-link d-none" id="toggleLastTrickButton" href=""></a>
                         </li>
                     </ul>
                 </div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,8 +1,10 @@
 ﻿<!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="bg-white">
 <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <title>@ViewData["Title"] - Schafkopf</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
@@ -22,15 +24,15 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
+                            <a class="nav-link text-dark" href="javascript:document.body.requestFullscreen();">Enter Fullscreen</a>
                         </li>
                     </ul>
                 </div>
             </div>
         </nav>
     </header>
-    <div class="container-fluid flex-grow-1 overflow-hidden">
-        <main role="main" class="pb-3 h-100 overflow-hidden">
+    <div class="container-fluid flex-grow-1 d-flex overflow-hidden">
+        <main role="main" class="pb-3 d-flex flex-grow-1 overflow-hidden">
             @RenderBody()
         </main>
     </div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -9,9 +9,9 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
 </head>
-<body class="d-flex flex-column vh-100 overflow-hidden">
+<body class="d-flex flex-column vh-100 overflow-hidden bg-white text-dark">
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark mb-3">
             <div class="container">
                 <a class="navbar-brand" asp-area="" asp-page="/Index">Schafkopf</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
@@ -21,13 +21,16 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
+                            <a class="nav-link" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" href="javascript:document.body.requestFullscreen();">Vollbild</a>
+                            <a class="nav-link" href="javascript:document.body.requestFullscreen();">Vollbild</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" id="toggleLastTrickButton" href=""></a>
+                            <a class="nav-link" id="toggleThemeButton" href="">Dark</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" id="toggleLastTrickButton" href=""></a>
                         </li>
                     </ul>
                 </div>

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -24,7 +24,10 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" href="javascript:document.body.requestFullscreen();">Enter Fullscreen</a>
+                            <a class="nav-link text-dark" href="javascript:document.body.requestFullscreen();">Vollbild</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" id="toggleLastTrickButton" href=""></a>
                         </li>
                     </ul>
                 </div>

--- a/wwwroot/carddecks/blank.svg
+++ b/wwwroot/carddecks/blank.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 51.593749 93.927086"
+   height="355"
+   width="195">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-203.0729)"
+     id="layer1" />
+</svg>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,13 +1,13 @@
 ﻿.card-on-table {
-    width: 12.5%;
-    transform-origin: 50% 0%;
-    position: absolute;
-    margin: auto;
-    left: 0;
-    right: 0;
-    z-index: 0;
-    pointer-events: none;
-    top: 50%;
+  width: 12.5%;
+  transform-origin: 50% 0%;
+  position: absolute;
+  margin: auto;
+  left: 0;
+  right: 0;
+  z-index: 0;
+  pointer-events: none;
+  top: 50%;
 }
 
 #hand {
@@ -31,11 +31,11 @@
 }
 
 .player-at-table {
-width: max-content;
-background-color: rgba(255, 255, 255, 0.8);
-color: black;
-padding: 5px;
-border-radius: 5px;
+  width: max-content;
+  background-color: rgba(255, 255, 255, 0.8);
+  color: black;
+  padding: 5px;
+  border-radius: 5px;
 }
 
 .active-player {
@@ -59,4 +59,20 @@ border-radius: 5px;
 
 #player-top {
   top: 5px;
+}
+
+#take-trick-btn {
+  width: max-content;
+  width: 100%;
+  height: 100%;
+  transform: translateY(-50%);
+  pointer-events: all;
+  position: absolute;
+}
+
+#take-trick-btn-content {
+  margin: auto;
+  text-align: center;
+  font-size: 1vw;
+  line-height: 1.3vw;
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -72,18 +72,19 @@ body {
   line-height: 60px; /* Vertically center the text there */
 }
 
-/* the positioning here is kinda hacky, but it works */
-
 .card-on-table {
     width: 12.5%;
-    transform: rotate(270deg) translateY(27.5%);
     transform-origin: 50% 0%;
     position: absolute;
     margin: auto;
     left: 0;
     right: 0;
-    top: 0;
-    bottom: 0;
+    z-index: 0;
+    pointer-events: none;
+}
+
+#hand {
+  z-index: 100;
 }
 
 #card-right {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -30,12 +30,15 @@
   transform: rotate(180deg) translateY(27.5%);
 }
 
-.player-at-table {
+.float-box {
   width: max-content;
+  height: max-content;
+  text-align: center;
   background-color: rgba(255, 255, 255, 0.8);
   color: black;
   padding: 5px;
   border-radius: 5px;
+  margin: auto;
 }
 
 .active-player {
@@ -43,26 +46,56 @@
 }
 
 #player-right {
+  max-width: 30%;
+  width: auto;
   transform: translateY(-50%);
   left: auto;
 }
 
 #player-left {
+  max-width: 30%;
+  width: auto;
   transform: translateY(-50%);
   right: auto;
 }
 
 #player-bottom {
+  max-width: 30%;
+  width: auto;
   top: auto;
   bottom: 5px;
 }
 
 #player-top {
+  max-width: 30%;
+  width: auto;
   top: 5px;
 }
 
+#player-left-name {
+  margin-right: 5px;
+}
+
+#player-right-name {
+  margin-left: 5px;
+}
+
+#player-top-name {
+  margin-bottom: 5px;
+}
+
+#player-bottom-name {
+  margin-top: 5px;
+}
+
+#game-info {
+  right: auto;
+  top: 5px;
+  margin-left:0;
+  max-width: 30%;
+}
+
 #take-trick-btn {
-  width: max-content;
   width: 100%;
   height: 100%;
   transform: translateY(-50%);

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -38,6 +38,10 @@ padding: 5px;
 border-radius: 5px;
 }
 
+.active-player {
+  background-color: rgba(255, 80, 0, 0.8);
+}
+
 #player-right {
   transform: translateY(-50%);
   left: auto;

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -34,7 +34,7 @@
   width: max-content;
   height: max-content;
   text-align: center;
-  background-color: rgba(255, 255, 255, 0.8);
+  background-color: rgba(180, 180, 180, 0.8);
   color: black;
   padding: 5px;
   border-radius: 5px;
@@ -64,6 +64,7 @@
   width: auto;
   top: auto;
   bottom: 5px;
+  pointer-events: all;
 }
 
 #player-top {

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -81,6 +81,7 @@ body {
     right: 0;
     z-index: 0;
     pointer-events: none;
+    top: 50%;
 }
 
 #hand {
@@ -101,4 +102,28 @@ body {
 
 #card-top {
   transform: rotate(180deg) translateY(27.5%);
+}
+
+.player-at-table {
+  width: min-content;
+  background-color: rgba(255, 255, 255, 0.7);
+}
+
+#player-right {
+  transform: translateY(-50%);
+  left: auto;
+}
+
+#player-left {
+  transform: translateY(-50%);
+  right: auto;
+}
+
+#player-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+#player-top {
+  top: 0;
 }

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -1,78 +1,4 @@
-﻿/* Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
-for details on configuring this project to bundle and minify static web assets. */
-
-a.navbar-brand {
-  white-space: normal;
-  text-align: center;
-  word-break: break-all;
-}
-
-/* Provide sufficient contrast against white background */
-a {
-  color: #0366d6;
-}
-
-.btn-primary {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
-}
-
-.nav-pills .nav-link.active,
-.nav-pills .show > .nav-link {
-  color: #fff;
-  background-color: #1b6ec2;
-  border-color: #1861ac;
-}
-
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  font-size: 14px;
-}
-@media (min-width: 768px) {
-  html {
-    font-size: 16px;
-  }
-}
-
-.border-top {
-  border-top: 1px solid #e5e5e5;
-}
-.border-bottom {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.box-shadow {
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.05);
-}
-
-button.accept-policy {
-  font-size: 1rem;
-  line-height: inherit;
-}
-
-/* Sticky footer styles
--------------------------------------------------- */
-html {
-  position: relative;
-  min-height: 100%;
-}
-
-body {
-  /* Margin bottom by footer height */
-  /* margin-bottom: 60px; */
-}
-
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  white-space: nowrap;
-  line-height: 60px; /* Vertically center the text there */
-}
-
-.card-on-table {
+﻿.card-on-table {
     width: 12.5%;
     transform-origin: 50% 0%;
     position: absolute;
@@ -105,8 +31,11 @@ body {
 }
 
 .player-at-table {
-  width: min-content;
-  background-color: rgba(255, 255, 255, 0.7);
+width: max-content;
+background-color: rgba(255, 255, 255, 0.8);
+color: black;
+padding: 5px;
+border-radius: 5px;
 }
 
 #player-right {
@@ -121,9 +50,9 @@ body {
 
 #player-bottom {
   top: auto;
-  bottom: 0;
+  bottom: 5px;
 }
 
 #player-top {
-  top: 0;
+  top: 5px;
 }

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -17,6 +17,29 @@ function tryReconnect() {
   }
 }
 
+function setTheme(theme) {
+  localStorage.setItem("theme", theme);
+  var button = document.getElementById("toggleThemeButton");
+  var body = document.getElementsByTagName("body")[0];
+  if (theme == "Dark") {
+    button.textContent = "Light";
+    body.classList.add("bg-dark");
+    body.classList.add("text-white");
+    body.classList.remove("bg-white");
+    body.classList.remove("text-dark");
+  } else {
+    button.textContent = "Dark";
+    body.classList.add("bg-white");
+    body.classList.add("text-dark");
+    body.classList.remove("bg-dark");
+    body.classList.remove("text-white");
+  }
+}
+
+try {
+  setTheme(localStorage.getItem("theme"));
+} catch { }
+
 var connection = new signalR.HubConnectionBuilder()
   .withUrl("/schafkopfHub")
   .build();
@@ -200,6 +223,7 @@ document
     connection.invoke("SendChatMessage", message).catch(function (err) {
       return console.error(err.toString());
     });
+    document.getElementById("messageInput").value = "";
     event.preventDefault();
   });
 
@@ -427,19 +451,6 @@ document
   .getElementById("toggleThemeButton")
   .addEventListener("click", function (event) {
     var button = document.getElementById("toggleThemeButton");
-    var body = document.getElementsByTagName("body")[0];
-    if (button.textContent.trim() == "Dark") {
-      button.textContent = "Light";
-      body.classList.add("bg-dark");
-      body.classList.add("text-white");
-      body.classList.remove("bg-white");
-      body.classList.remove("text-dark");
-    } else {
-      button.textContent = "Dark";
-      body.classList.add("bg-white");
-      body.classList.add("text-dark");
-      body.classList.remove("bg-dark");
-      body.classList.remove("text-white");
-    }
+    setTheme(button.textContent.trim());
     event.preventDefault();
   });

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -1,5 +1,29 @@
 "use strict";
 
+const modalState = {};
+
+function showModal(modal) {
+  modalState[modal] = true;
+  $(modal).modal({ keyboard: false, backdrop: "static" });
+
+  $(modal).on('hidden.bs.modal', function (e) {
+    if (modalState[modal]) {
+      $(modal).modal({ keyboard: false, backdrop: "static" });
+    }
+  })
+}
+
+function hideModal(modal) {
+  modalState[modal] = false;
+  $(modal).modal('hide');
+
+  $(modal).on('shown.bs.modal', function (e) {
+    if (!modalState[modal]) {
+      $(modal).modal('hide');
+    }
+  })
+}
+
 function tryReconnect() {
   // The following code allows a user to reconnect after reloading the page or restarting the browser
   // During development this is not useful as it is more difficult to simulate multiple users from one machine
@@ -13,7 +37,7 @@ function tryReconnect() {
         return console.error(err.toString());
       });
   } else {
-    $('#usernameModal').modal({ keyboard: false, backdrop: "static" });
+    showModal('#usernameModal');
   }
 }
 
@@ -71,40 +95,40 @@ connection.on("ReceiveSystemMessage", function (message) {
 
 connection.on("AskUsername", function (message) {
   localStorage.removeItem("userId");
-  $('#usernameModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#usernameModal');
 });
 
 connection.on("GameOver", function (title, body) {
   document.getElementById("gameOverModalTitle").textContent = title;
   document.getElementById("gameOverModalBody").textContent = body;
-  $('#gameOverModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#gameOverModal');
 });
 
 connection.on("AskAnnounce", function (message) {
   document.getElementById("announceModalTitle").textContent = "Magst du spielen?";
-  $('#announceModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#announceModal');
 });
 
 connection.on("AskGameType", function (message) {
-  $('#announceGameTypeModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#announceGameTypeModal');
 });
 
 connection.on("AskColor", function (message) {
-  $('#gameColorModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#gameColorModal');
 });
 
 connection.on("AskWantToPlay", function () {
-  $('#wantToPlayModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#wantToPlayModal');
 });
 
 connection.on("AskAnnounceHochzeit", function (message) {
   document.getElementById("announceModalTitle").textContent = "Magst du eine Hochzeit anbieten?";
-  $('#announceModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#announceModal');
 });
 
 connection.on("AskWantToMarryPlayer", function (message) {
   document.getElementById("announceModalTitle").textContent = `Magst du ${message} heiraten?`;
-  $('#announceModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#announceModal');
 });
 
 connection.on("AskWantToSpectate", function (players) {
@@ -112,45 +136,45 @@ connection.on("AskWantToSpectate", function (players) {
   document.getElementById("wantToSpectatePlayer2Button").textContent = players[1];
   document.getElementById("wantToSpectatePlayer3Button").textContent = players[2];
   document.getElementById("wantToSpectatePlayer4Button").textContent = players[3];
-  $('#wantToSpectateModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#wantToSpectateModal');
 });
 
 connection.on("AskAllowSpectator", function (player) {
   document.getElementById("allowSpectatorModalTitle").textContent = `Erlaubst du ${player} bei dir zuzuschauen?`;
-  $('#allowSpectatorModal').modal({ keyboard: false, backdrop: "static" });
+  showModal('#allowSpectatorModal');
 })
 
 connection.on("CloseGameOverModal", function () {
-  $('#gameOverModal').modal('hide');
+  hideModal('#gameOverModal');
 });
 
 connection.on("CloseAnnounceModal", function () {
-  $('#announceModal').modal('hide');
+  hideModal('#announceModal');
 });
 
 connection.on("CloseAnnounceGameTypeModal", function () {
-  $('#announceGameTypeModal').modal('hide');
+  hideModal('#announceGameTypeModal');
 });
 
 connection.on("CloseGameColorModal", function () {
-  $('#gameColorModal').modal('hide');
+  hideModal('#gameColorModal');
 });
 
 connection.on("CloseWantToPlayModal", function () {
-  $('#wantToPlayModal').modal('hide');
+  hideModal('#wantToPlayModal');
 });
 
 connection.on("CloseWantToSpectateModal", function () {
-  $('#wantToSpectateModal').modal('hide');
+  hideModal('#wantToSpectateModal');
 });
 
 connection.on("CloseAllowSpectatorModal", function (player) {
-  $('#allowSpectatorModal').modal('hide');
+  hideModal('#allowSpectatorModal');
 })
 
 connection.on("StoreUserId", function (id) {
   localStorage.setItem("userId", id);
-  $('#usernameModal').modal('hide');
+  hideModal('#usernameModal');
 });
 
 connection.on("ReceiveHand", function (cards) {
@@ -196,13 +220,37 @@ connection.on("ReceiveTrick", function (cards) {
 connection.on("ReceiveLastTrickButton", function (buttonState) {
   switch (buttonState) {
     case "disabled":
-      document.getElementById("toggleLastTrickButton").textContent = "";
+      document.getElementById("toggleLastTrickButton").classList.add("d-none");
       break;
     case "show":
+      document.getElementById("toggleLastTrickButton").classList.remove("d-none");
       document.getElementById("toggleLastTrickButton").textContent = "Letzten Stich zeigen";
       break;
     case "hide":
+      document.getElementById("toggleLastTrickButton").classList.remove("d-none");
       document.getElementById("toggleLastTrickButton").textContent = "Letzten Stich verstecken";
+      break;
+  }
+});
+
+connection.on("ReceiveTakeTrickButton", function (buttonState, winner) {
+  const btn = document.getElementById("take-trick-btn");
+  const content = document.getElementById("take-trick-btn-content");
+  btn.classList.remove("d-none");
+  btn.classList.remove("btn-primary");
+  btn.classList.remove("btn-secondary");
+  switch (buttonState) {
+    case "hidden":
+      content.textContent = "";
+      btn.classList.add("d-none");
+      break;
+    case "won":
+      content.textContent = "Stich nehmen!";
+      btn.classList.add("btn-primary");
+      break;
+    case "lost":
+      content.textContent = `${winner} hat den Stich gewonnen.`;
+      btn.classList.add("btn-secondary");
       break;
   }
 });
@@ -213,7 +261,7 @@ connection
     document.getElementById("sendButton").disabled = false;
     let searchParams = new URLSearchParams(window.location.search);
     if (!searchParams.get("game")) {
-      $('#gameIdModal').modal({ keyboard: false, backdrop: "static" });
+      showModal('#gameIdModal');
       return;
     }
     tryReconnect();
@@ -428,7 +476,7 @@ document
 document
   .getElementById("gameIdSubmitButton")
   .addEventListener("click", function (event) {
-    $('#gameIdModal').modal('hide');
+    hideModal('#gameIdModal');
     let searchParams = new URLSearchParams(window.location.search);
     searchParams.set("game", document.getElementById("gameIdInput").value)
     window.location.search = searchParams.toString();
@@ -450,6 +498,16 @@ document
           return console.error(err.toString());
         });
     }
+    event.preventDefault();
+  });
+
+document
+  .getElementById("take-trick-btn")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("TakeTrick").catch(function (err) {
+        return console.error(err.toString());
+      });
     event.preventDefault();
   });
 

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -44,18 +44,30 @@ connection.on("AskColor", function (message) {
 });
 
 connection.on("AskWantToPlay", function () {
-  if (!userId) {
-    return;
-  }
-  $('#gameOverModal').modal('hide');
   $('#wantToPlayModal').modal({ keyboard: false, backdrop: "static" });
 });
 
-connection.on("GameOver", function (title, body) {
+connection.on("CloseGameOverModal", function () {
+  $('#gameOverModal').modal('hide');
+});
+
+connection.on("CloseAnnounceModal", function () {
   $('#announceModal').modal('hide');
+});
+
+connection.on("CloseAnnounceGameTypeModal", function () {
   $('#announceGameTypeModal').modal('hide');
-  $('#wantToPlayModal').modal('hide');
+});
+
+connection.on("CloseGameColorModal", function () {
   $('#gameColorModal').modal('hide');
+});
+
+connection.on("CloseWantToPlayModal", function () {
+  $('#wantToPlayModal').modal('hide');
+});
+
+connection.on("GameOver", function (title, body) {
   document.getElementById("gameOverModalTitle").textContent = title;
   document.getElementById("gameOverModalBody").textContent = body;
   $('#gameOverModal').modal({ keyboard: false, backdrop: "static" });

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -422,3 +422,24 @@ document
     }
     event.preventDefault();
   });
+
+document
+  .getElementById("toggleThemeButton")
+  .addEventListener("click", function (event) {
+    var button = document.getElementById("toggleThemeButton");
+    var body = document.getElementsByTagName("body")[0];
+    if (button.textContent.trim() == "Dark") {
+      button.textContent = "Light";
+      body.classList.add("bg-dark");
+      body.classList.add("text-white");
+      body.classList.remove("bg-white");
+      body.classList.remove("text-dark");
+    } else {
+      button.textContent = "Dark";
+      body.classList.add("bg-white");
+      body.classList.add("text-dark");
+      body.classList.remove("bg-dark");
+      body.classList.remove("text-white");
+    }
+    event.preventDefault();
+  });

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -208,17 +208,24 @@ connection.on("ReceiveHand", function (cards) {
   }
 });
 
-connection.on("ReceivePlayers", function (players, actionPlayer) {
+connection.on("ReceivePlayers", function (players, infos, actionPlayer) {
   const playersPositions = new Array("player-bottom", "player-left", "player-top", "player-right");
   for (let i = 0; i < 4; i++) {
-    const player = document.getElementById(playersPositions[i]);
+    const player = document.getElementById(playersPositions[i] + "-name");
+    const info = document.getElementById(playersPositions[i] + "-info");
     player.textContent = players[i];
+    info.textContent = infos[i]
     if (i == actionPlayer) {
       player.classList.add("active-player");
     } else {
       player.classList.remove("active-player");
     }
   }
+});
+
+connection.on("ReceiveGameInfo", function (message) {
+  const info = document.getElementById("game-info");
+  info.textContent = message;
 });
 
 connection.on("ReceiveTrick", function (cards) {

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -1,7 +1,5 @@
 "use strict";
 
-var userId = "";
-
 var connection = new signalR.HubConnectionBuilder()
   .withUrl("/schafkopfHub")
   .build();
@@ -31,6 +29,17 @@ connection.on("ReceiveSystemMessage", function (message) {
   messageList.scrollTop = messageList.scrollHeight;
 });
 
+connection.on("AskUsername", function (message) {
+  localStorage.removeItem("userId");
+  $('#usernameModal').modal({ keyboard: false, backdrop: "static" });
+});
+
+connection.on("GameOver", function (title, body) {
+  document.getElementById("gameOverModalTitle").textContent = title;
+  document.getElementById("gameOverModalBody").textContent = body;
+  $('#gameOverModal').modal({ keyboard: false, backdrop: "static" });
+});
+
 connection.on("AskAnnounce", function (message) {
   $('#announceModal').modal({ keyboard: false, backdrop: "static" });
 });
@@ -46,6 +55,19 @@ connection.on("AskColor", function (message) {
 connection.on("AskWantToPlay", function () {
   $('#wantToPlayModal').modal({ keyboard: false, backdrop: "static" });
 });
+
+connection.on("AskWantToSpectate", function (players) {
+  document.getElementById("wantToSpectatePlayer1Button").textContent = players[0];
+  document.getElementById("wantToSpectatePlayer2Button").textContent = players[1];
+  document.getElementById("wantToSpectatePlayer3Button").textContent = players[2];
+  document.getElementById("wantToSpectatePlayer4Button").textContent = players[3];
+  $('#wantToSpectateModal').modal({ keyboard: false, backdrop: "static" });
+});
+
+connection.on("AskAllowSpectator", function (player) {
+  document.getElementById("allowSpectatorModalTitle").textContent = `Erlaubst du ${player} bei dir zuzuschauen?`;
+  $('#allowSpectatorModal').modal({ keyboard: false, backdrop: "static" });
+})
 
 connection.on("CloseGameOverModal", function () {
   $('#gameOverModal').modal('hide');
@@ -67,15 +89,17 @@ connection.on("CloseWantToPlayModal", function () {
   $('#wantToPlayModal').modal('hide');
 });
 
-connection.on("GameOver", function (title, body) {
-  document.getElementById("gameOverModalTitle").textContent = title;
-  document.getElementById("gameOverModalBody").textContent = body;
-  $('#gameOverModal').modal({ keyboard: false, backdrop: "static" });
+connection.on("CloseWantToSpectateModal", function () {
+  $('#wantToSpectateModal').modal('hide');
 });
+
+connection.on("CloseAllowSpectatorModal", function (player) {
+  $('#allowSpectatorModal').modal('hide');
+})
 
 connection.on("StoreUserId", function (id) {
   localStorage.setItem("userId", id);
-  userId = id;
+  $('#usernameModal').modal('hide');
 });
 
 connection.on("ReceiveHand", function (cards) {
@@ -120,17 +144,14 @@ connection
     // During development this is not useful as it is more difficult to simulate multiple users from one machine
     // append `?session=new` to the url to force a new connection
     let searchParams = new URLSearchParams(window.location.search);
-    userId = localStorage.getItem("userId");
+    var userId = localStorage.getItem("userId");
     if (userId && !(searchParams.get("session") == "new")) {
       connection
         .invoke("ReconnectPlayer", userId)
         .catch(function (err) {
-          localStorage.removeItem("userId");
-          $('#usernameModal').modal({ keyboard: false, backdrop: "static" });
           return console.error(err.toString());
         });
     } else {
-      userId = "";
       $('#usernameModal').modal({ keyboard: false, backdrop: "static" });
     }
   })
@@ -264,6 +285,76 @@ document
   .addEventListener("click", function (event) {
     connection
       .invoke("ResetGame",).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("doNotSpectateButton")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("PlayerWantsToSpectate", -1).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("wantToSpectatePlayer1Button")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("PlayerWantsToSpectate", 0).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("wantToSpectatePlayer2Button")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("PlayerWantsToSpectate", 1).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("wantToSpectatePlayer3Button")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("PlayerWantsToSpectate", 2).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("wantToSpectatePlayer4Button")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("PlayerWantsToSpectate", 3).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("doNotAllowSpectatorButton")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("AllowSpectator", false).catch(function (err) {
+        return console.error(err.toString());
+      });
+    event.preventDefault();
+  });
+
+document
+  .getElementById("allowSpectatorButton")
+  .addEventListener("click", function (event) {
+    connection
+      .invoke("AllowSpectator", true).catch(function (err) {
         return console.error(err.toString());
       });
     event.preventDefault();

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -173,11 +173,17 @@ connection.on("ReceiveHand", function (cards) {
   }
 });
 
-connection.on("ReceivePlayers", function (players) {
-  document.getElementById("player-bottom").textContent = players[0];
-  document.getElementById("player-left").textContent = players[1];
-  document.getElementById("player-top").textContent = players[2];
-  document.getElementById("player-right").textContent = players[3];
+connection.on("ReceivePlayers", function (players, actionPlayer) {
+  const playersPositions = new Array("player-bottom", "player-left", "player-top", "player-right");
+  for (let i = 0; i < 4; i++) {
+    const player = document.getElementById(playersPositions[i]);
+    player.textContent = players[i];
+    if (i == actionPlayer) {
+      player.classList.add("active-player");
+    } else {
+      player.classList.remove("active-player");
+    }
+  }
 });
 
 connection.on("ReceiveTrick", function (cards) {

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -130,14 +130,17 @@ connection.on("AskColor", function (message) {
   showModal('#gameColorModal');
 });
 
-connection.on("AskWantToPlay", function (players, startPlayer) {
+connection.on("AskWantToPlay", function (players, startPlayer, proposal) {
   document.getElementById("wantToPlayModalBody").innerHTML = "";
   const playersDiv = document.createElement("div");
   playersDiv.textContent = `Spieler: ${players}`
   const startPlayerDiv = document.createElement("div");
   startPlayerDiv.textContent = `${startPlayer} kommt als nächstes raus.`
+  const proposalDiv = document.createElement("div");
+  proposalDiv.textContent = `Vorschlag: ${proposal}`
   document.getElementById("wantToPlayModalBody").appendChild(playersDiv);
   document.getElementById("wantToPlayModalBody").appendChild(startPlayerDiv);
+  document.getElementById("wantToPlayModalBody").appendChild(proposalDiv);
   showModal('#wantToPlayModal');
 });
 

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -58,6 +58,7 @@ connection.on("GameOver", function (title, body) {
 });
 
 connection.on("AskAnnounce", function (message) {
+  document.getElementById("announceModalTitle").textContent = "Magst du spielen?";
   $('#announceModal').modal({ keyboard: false, backdrop: "static" });
 });
 
@@ -71,6 +72,16 @@ connection.on("AskColor", function (message) {
 
 connection.on("AskWantToPlay", function () {
   $('#wantToPlayModal').modal({ keyboard: false, backdrop: "static" });
+});
+
+connection.on("AskAnnounceHochzeit", function (message) {
+  document.getElementById("announceModalTitle").textContent = "Magst du eine Hochzeit anbieten?";
+  $('#announceModal').modal({ keyboard: false, backdrop: "static" });
+});
+
+connection.on("AskWantToMarryPlayer", function (message) {
+  document.getElementById("announceModalTitle").textContent = `Magst du ${message} heiraten?`;
+  $('#announceModal').modal({ keyboard: false, backdrop: "static" });
 });
 
 connection.on("AskWantToSpectate", function (players) {

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -130,7 +130,14 @@ connection.on("AskColor", function (message) {
   showModal('#gameColorModal');
 });
 
-connection.on("AskWantToPlay", function () {
+connection.on("AskWantToPlay", function (players, startPlayer) {
+  document.getElementById("wantToPlayModalBody").innerHTML = "";
+  const playersDiv = document.createElement("div");
+  playersDiv.textContent = `Spieler: ${players}`
+  const startPlayerDiv = document.createElement("div");
+  startPlayerDiv.textContent = `${startPlayer} kommt als nächstes raus.`
+  document.getElementById("wantToPlayModalBody").appendChild(playersDiv);
+  document.getElementById("wantToPlayModalBody").appendChild(startPlayerDiv);
   showModal('#wantToPlayModal');
 });
 

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -106,6 +106,11 @@ function init() {
     document.getElementById("card-left").src = "/carddecks/blank.svg";
     document.getElementById("card-top").src = "/carddecks/blank.svg";
     document.getElementById("card-right").src = "/carddecks/blank.svg";
+    const btn = document.getElementById("take-trick-btn");
+    btn.classList.add("d-none");
+    btn.classList.remove("btn-primary");
+    btn.classList.remove("btn-secondary");
+    document.getElementById("take-trick-btn-content").textContent = "";
     hideModal('#gameOverModal');
     hideModal('#gameIdModal');
     hideModal('#announceModal');

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -66,6 +66,9 @@ function connect() {
       let searchParams = new URLSearchParams(window.location.search);
       if (!searchParams.get("game")) {
         showModal('#gameIdModal');
+        $('#gameIdModal').on('shown.bs.modal', function () {
+          $('#gameIdInput').focus();
+        })
         return;
       }
       tryReconnect();
@@ -97,6 +100,12 @@ function setTheme(theme) {
 
 function init() {
   connection.onclose(() => {
+    document.getElementById("game-info").textContent = "";
+    document.getElementById("hand").innerHTML = "";
+    document.getElementById("card-bottom").src = "/carddecks/blank.svg";
+    document.getElementById("card-left").src = "/carddecks/blank.svg";
+    document.getElementById("card-top").src = "/carddecks/blank.svg";
+    document.getElementById("card-right").src = "/carddecks/blank.svg";
     hideModal('#gameOverModal');
     hideModal('#gameIdModal');
     hideModal('#announceModal');

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -147,10 +147,10 @@ connection.on("ReceivePlayers", function (players) {
 });
 
 connection.on("ReceiveTrick", function (cards) {
-    document.getElementById("card-bottom").src = cards[0] != "" ? `/carddecks/noto/${cards[0]}.svg` : "";
-    document.getElementById("card-left").src = cards[1] != "" ? `/carddecks/noto/${cards[1]}.svg` : "";
-    document.getElementById("card-top").src = cards[2] != "" ? `/carddecks/noto/${cards[2]}.svg` : "";
-    document.getElementById("card-right").src = cards[3] != "" ? `/carddecks/noto/${cards[3]}.svg` : "";
+  document.getElementById("card-bottom").src = cards[0] != "" ? `/carddecks/noto/${cards[0]}.svg` : "/carddecks/blank.svg";
+    document.getElementById("card-left").src = cards[1] != "" ? `/carddecks/noto/${cards[1]}.svg` : "/carddecks/blank.svg";
+    document.getElementById("card-top").src = cards[2] != "" ? `/carddecks/noto/${cards[2]}.svg` : "/carddecks/blank.svg";
+    document.getElementById("card-right").src = cards[3] != "" ? `/carddecks/noto/${cards[3]}.svg` : "/carddecks/blank.svg";
 });
 
 connection

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -37,6 +37,7 @@ function tryReconnect() {
         return console.error(err.toString());
       });
   } else {
+    document.getElementById("startModalUserName").value = localStorage.getItem("userName");
     showModal('#usernameModal');
     $('#usernameModal').on('shown.bs.modal', function () {
       $('#startModalUserName').focus();
@@ -103,6 +104,7 @@ connection.on("ReceiveSystemMessage", function (message) {
 
 connection.on("AskUsername", function (message) {
   localStorage.removeItem("userId");
+  document.getElementById("startModalUserName").value = localStorage.getItem("userName");
   showModal('#usernameModal');
   $('#usernameModal').on('shown.bs.modal', function () {
     $('#startModalUserName').focus();
@@ -183,8 +185,9 @@ connection.on("CloseAllowSpectatorModal", function (player) {
   hideModal('#allowSpectatorModal');
 })
 
-connection.on("StoreUserId", function (id) {
+connection.on("StoreUser", function (id, name) {
   localStorage.setItem("userId", id);
+  localStorage.setItem("userName", name);
   hideModal('#usernameModal');
 });
 
@@ -426,16 +429,6 @@ document
   });
 
 document
-  .getElementById("doNotSpectateButton")
-  .addEventListener("click", function (event) {
-    connection
-      .invoke("PlayerWantsToSpectate", -1).catch(function (err) {
-        return console.error(err.toString());
-      });
-    event.preventDefault();
-  });
-
-document
   .getElementById("wantToSpectatePlayer1Button")
   .addEventListener("click", function (event) {
     connection
@@ -538,5 +531,16 @@ document
   .addEventListener("click", function (event) {
     var button = document.getElementById("toggleThemeButton");
     setTheme(button.textContent.trim());
+    event.preventDefault();
+  });
+
+document
+  .getElementById("player-bottom-name")
+  .addEventListener("click", function (event) {
+    document.getElementById("startModalUserName").value = localStorage.getItem("userName");
+    showModal('#usernameModal');
+    $('#usernameModal').on('shown.bs.modal', function () {
+      $('#startModalUserName').focus();
+    })
     event.preventDefault();
   });

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -148,9 +148,23 @@ connection.on("ReceivePlayers", function (players) {
 
 connection.on("ReceiveTrick", function (cards) {
   document.getElementById("card-bottom").src = cards[0] != "" ? `/carddecks/noto/${cards[0]}.svg` : "/carddecks/blank.svg";
-    document.getElementById("card-left").src = cards[1] != "" ? `/carddecks/noto/${cards[1]}.svg` : "/carddecks/blank.svg";
-    document.getElementById("card-top").src = cards[2] != "" ? `/carddecks/noto/${cards[2]}.svg` : "/carddecks/blank.svg";
-    document.getElementById("card-right").src = cards[3] != "" ? `/carddecks/noto/${cards[3]}.svg` : "/carddecks/blank.svg";
+  document.getElementById("card-left").src = cards[1] != "" ? `/carddecks/noto/${cards[1]}.svg` : "/carddecks/blank.svg";
+  document.getElementById("card-top").src = cards[2] != "" ? `/carddecks/noto/${cards[2]}.svg` : "/carddecks/blank.svg";
+  document.getElementById("card-right").src = cards[3] != "" ? `/carddecks/noto/${cards[3]}.svg` : "/carddecks/blank.svg";
+});
+
+connection.on("ReceiveLastTrickButton", function (buttonState) {
+  switch (buttonState) {
+    case "disabled":
+      document.getElementById("toggleLastTrickButton").textContent = "";
+      break;
+    case "show":
+      document.getElementById("toggleLastTrickButton").textContent = "Letzten Stich zeigen";
+      break;
+    case "hide":
+      document.getElementById("toggleLastTrickButton").textContent = "Letzten Stich verstecken";
+      break;
+  }
 });
 
 connection
@@ -294,7 +308,7 @@ document
   .getElementById("restartButton")
   .addEventListener("click", function (event) {
     connection
-      .invoke("ResetGame",).catch(function (err) {
+      .invoke("ResetGame").catch(function (err) {
         return console.error(err.toString());
       });
     event.preventDefault();
@@ -378,5 +392,22 @@ document
     searchParams.set("game", document.getElementById("gameIdInput").value)
     window.location.search = searchParams.toString();
     tryReconnect();
+    event.preventDefault();
+  });
+
+document
+  .getElementById("toggleLastTrickButton")
+  .addEventListener("click", function (event) {
+    if (document.getElementById("toggleLastTrickButton").textContent.trim() == "Letzten Stich verstecken") {
+      connection
+        .invoke("ShowLastTrick", false).catch(function (err) {
+          return console.error(err.toString());
+        });
+    } else if (document.getElementById("toggleLastTrickButton").textContent.trim() == "Letzten Stich zeigen") {
+      connection
+        .invoke("ShowLastTrick", true).catch(function (err) {
+          return console.error(err.toString());
+        });
+    }
     event.preventDefault();
   });

--- a/wwwroot/js/schafkopf.js
+++ b/wwwroot/js/schafkopf.js
@@ -38,6 +38,9 @@ function tryReconnect() {
       });
   } else {
     showModal('#usernameModal');
+    $('#usernameModal').on('shown.bs.modal', function () {
+      $('#startModalUserName').focus();
+    })
   }
 }
 
@@ -83,6 +86,11 @@ connection.on("ReceiveChatMessage", function (user, message) {
 });
 
 connection.on("ReceiveSystemMessage", function (message) {
+  if (message.startsWith("Error: ")) {
+    document.getElementById("errorModalBody").textContent = message;
+    $("#errorModal").modal();
+  }
+
   var div = document.createElement("div");
   var userB = div.appendChild(document.createElement("b"));
   var msgSpan = div.appendChild(document.createElement("span"));
@@ -96,6 +104,9 @@ connection.on("ReceiveSystemMessage", function (message) {
 connection.on("AskUsername", function (message) {
   localStorage.removeItem("userId");
   showModal('#usernameModal');
+  $('#usernameModal').on('shown.bs.modal', function () {
+    $('#startModalUserName').focus();
+  })
 });
 
 connection.on("GameOver", function (title, body) {
@@ -383,14 +394,18 @@ document
 document
   .getElementById("startButton")
   .addEventListener("click", function (event) {
+    event.preventDefault();
     let searchParams = new URLSearchParams(window.location.search);
     var userName = document.getElementById("startModalUserName").value;
+    if (userName === "") {
+      return;
+    }
+    document.getElementById("startModalUserName").value = "";
     connection
       .invoke("AddPlayer", userName, searchParams.get("game"))
       .catch(function (err) {
         return console.error(err.toString());
       });
-    event.preventDefault();
   });
 
 document


### PR DESCRIPTION
- Order of Players at the table is persisted
- Names of the players are displayed
- Reconnect during the game is supported
   - for development use `?session=new` to force the creation of a new session 
- Spectator mode: a player that is not one of the four main players can ask one of them to see their cards
- Fix trick initialization (cause of bug in Wenz)
- Support multiple games on a single server
- Allow only valid cards to be played 
- Validate Sauspiel Announcement
- Add possibility to show last trick
- Support Hochzeit
- Indicate in orange which player is playing
- Add a button to take the trick
- Change username by clicking on it
- Display information about the game state on the table